### PR TITLE
Hiding MathJax in speaker notes

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -64,6 +64,20 @@
 				right: 0;
 				top: 0;
 			}
+			
+			#hide Mathjax-Assist 
+			.MJX_Assistive_MathML {
+				position: absolute!important;
+				top: 0;
+				left: 0;
+				clip: rect(1px, 1px, 1px, 1px);
+				padding: 1px 0 0 0!important;
+				border: 0!important;
+				height: 1px!important;
+				width: 1px!important;
+				overflow: hidden!important;
+				display: block!important;
+			}
 
 			/* Speaker controls */
 			#speaker-controls {


### PR DESCRIPTION
Mathjax-Assist- span was not hidden in Notes.

CSS-style from main part was inserted.
Fixes Issue #1726.